### PR TITLE
Updated link to project license in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ As mentioned above, scraperjs is uses some dependencies to do the the heavy work
 
 # License
 
-This project is under the [MIT](./LICENCE) license. 
+This project is under the [MIT](./LICENSE) license. 


### PR DESCRIPTION
The link to the project license was incorrect and returning a 404 error so I updated it to point to the correct file.