### PR TITLE
Passing utils to the error callback

### DIFF
--- a/src/ScraperPromise.js
+++ b/src/ScraperPromise.js
@@ -272,7 +272,7 @@ ScraperPromise.prototype = {
 		this.chainParameter = null;
 
 		if (error) {
-			this.errorCallback(error);
+			this.errorCallback(error, utils);
 			this.doneCallback(utils);
 			return;
 		}


### PR DESCRIPTION
This change attempts at giving a workaround and possibly closes #34 which is more likely a NodeJS issue (and there is not much we can do about it).