### PR TITLE
Add an 'options' argument to DynamicScraper that get passed to Phantom

### DIFF
--- a/src/AbstractScraper.js
+++ b/src/AbstractScraper.js
@@ -186,8 +186,8 @@ AbstractScraper.prototype = {
  * @public
  * @static
  */
-AbstractScraper.create = function(ScraperType, url) {
-	var promise = new ScraperPromise(new ScraperType());
+AbstractScraper.create = function(ScraperType, url, options) {
+	var promise = new ScraperPromise(new ScraperType(options));
 	if (url) {
 		promise.get(url);
 	}

--- a/src/DynamicScraper.js
+++ b/src/DynamicScraper.js
@@ -36,7 +36,7 @@ var DynamicScraper = function(options) {
 	this.options = {
 		onStdout: function() {},
 		onStderr: function() {}
-	}
+	};
 	for (var key in options) { this.options[key] = options[key]; }
 };
 DynamicScraper.prototype = Object.create(AbstractScraper.prototype);

--- a/src/DynamicScraper.js
+++ b/src/DynamicScraper.js
@@ -11,7 +11,7 @@ var phantomOrig = require('phantom'),
  *
  * @extends {AbstractScraper}
  */
-var DynamicScraper = function() {
+var DynamicScraper = function(options) {
 	AbstractScraper.call(this);
 	/**
 	 * Phantom instance.
@@ -27,6 +27,17 @@ var DynamicScraper = function() {
 	 * @private
 	 */
 	this.page = null;
+	/**
+	 * Phantom's options
+	 *
+	 * @type {?}
+	 * @private
+	 */
+	this.options = {
+		onStdout: function() {},
+		onStderr: function() {}
+	}
+	for (var key in options) { this.options[key] = options[key]; }
 };
 DynamicScraper.prototype = Object.create(AbstractScraper.prototype);
 /**
@@ -35,10 +46,7 @@ DynamicScraper.prototype = Object.create(AbstractScraper.prototype);
  */
 DynamicScraper.prototype.loadBody = function(done) {
 	var that = this;
-	phantom.create('--load-images=no', {
-		onStdout: function() {},
-		onStderr: function() {}
-	}, function(ph) {
+	phantom.create('--load-images=no', that.options, function(ph) {
 		that.ph = ph;
 		ph.createPage(function(page) {
 			that.page = page;
@@ -127,8 +135,8 @@ DynamicScraper.prototype.clone = function() {
  * @public
  * @static
  */
-DynamicScraper.create = function(url) {
-	return AbstractScraper.create(DynamicScraper, url);
+DynamicScraper.create = function(url, options) {
+	return AbstractScraper.create(DynamicScraper, url, options);
 };
 /**
  * Starts the factory. A factory should only be open once, and after


### PR DESCRIPTION
Add an 'options' argument to DynamicScraper that get passed to Phantom. Allows user to set Phantom's port and fixes #41.