### PR TITLE
Remove weak/node-gyp dependency

### DIFF
--- a/src/DynamicScraper.js
+++ b/src/DynamicScraper.js
@@ -36,7 +36,10 @@ var DynamicScraper = function(options) {
 	 */
 	this.options = {
 		onStdout: function() {},
-		onStderr: function() {}
+		onStderr: function() {},
+        dnodeOpts: {
+            weak: false
+        }
 	};
 	for (var key in options) { this.options[key] = options[key]; }
 };

--- a/src/DynamicScraper.js
+++ b/src/DynamicScraper.js
@@ -37,9 +37,9 @@ var DynamicScraper = function(options) {
 	this.options = {
 		onStdout: function() {},
 		onStderr: function() {},
-        dnodeOpts: {
-            weak: false
-        }
+		dnodeOpts: {
+			weak: false
+		}
 	};
 	for (var key in options) { this.options[key] = options[key]; }
 };

--- a/src/PhantomPoll.js
+++ b/src/PhantomPoll.js
@@ -39,9 +39,9 @@ var PhantomPoll = function() {
 	this.options = {
 		onStdout: function() {},
 		onStderr: function() {},
-        dnodeOpts: {
-            weak: false
-        }
+		dnodeOpts: {
+			weak: false
+		}
 	};
 	/**
 	 * List of functions waiting to be called after the PhantomJS

--- a/src/PhantomPoll.js
+++ b/src/PhantomPoll.js
@@ -38,7 +38,10 @@ var PhantomPoll = function() {
 	 */
 	this.options = {
 		onStdout: function() {},
-		onStderr: function() {}
+		onStderr: function() {},
+        dnodeOpts: {
+            weak: false
+        }
 	};
 	/**
 	 * List of functions waiting to be called after the PhantomJS


### PR DESCRIPTION
When running Phantom on a Windows box it defaults to requiring node-gyp. However, this is not required; please see https://github.com/amir20/phantomjs-node/tree/v1#use-it-in-windows. This should also address an old issue #2.